### PR TITLE
fix: fixed CornerRadius defaulting to UDim2 instead of UDim

### DIFF
--- a/src/StudioComponents/BaseScrollFrame/init.luau
+++ b/src/StudioComponents/BaseScrollFrame/init.luau
@@ -95,7 +95,7 @@ return function(Scope: { [any]: any }): (props: BaseScrollFrameProperties) -> Fr
 			[Children] = {
 				Scope:New "UICorner" {
 					Name = "UICorner",
-					CornerRadius = props.CornerRadius or UDim2.new(),
+					CornerRadius = props.CornerRadius or UDim.new(),
 				},
 
 				ScrollBar {


### PR DESCRIPTION
Fixed a UICorner's CornerRadius value defaulting to UDim2.new() instead of UDim.new(). The CornerRadius property expects a UDim value.