### PR TITLE
fix: temporary fix for component themes not updating on Studio.ThemeC…

### DIFF
--- a/src/StudioComponents/Util/themeProvider.luau
+++ b/src/StudioComponents/Util/themeProvider.luau
@@ -66,6 +66,7 @@ function themeProvider:GetColor(studioStyleGuideColor: styleStyleGuideColor, stu
 	local nScope = if hasState then Fusion:scoped() else nil
 	
 	return if not hasState then themeValue else Scope:Computed(function(use, scope)
+		use(themeValue)
 		local currentColor = unwrap(studioStyleGuideColor, use)
 		local currentModifier = unwrap(studioStyleGuideModifier, use)
 		local currentValueState = self:GetColor(currentColor, currentModifier, nScope)


### PR DESCRIPTION
Temporary hack to fix studio components not updating their colors to match the theme when there is a given modifier parameter passed into the themeProvider:GetColor method